### PR TITLE
Migrate infer deal tab to new deal page

### DIFF
--- a/app/(protected)/new-deal/page.tsx
+++ b/app/(protected)/new-deal/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import CreateNewDealForm from "@/components/forms/new-deal-form";
 import { Metadata } from "next";
 import { BulkImportDialog } from "@/components/Dialogs/bulk-import-dialog";
+import { InferDealDialog } from "@/components/Dialogs/infer-deal-dialog";
 
 export const metadata: Metadata = {
   title: "Add New Deal",
@@ -55,11 +56,7 @@ const NewDealPage = async () => {
                 accordingly
               </p>
               <div className="flex justify-center">
-                <Button className="w-full" asChild>
-                  <Link href="/infer">
-                    <Bot className="mr-2 h-4 w-4" /> Infer Deal
-                  </Link>
-                </Button>
+              <InferDealDialog />
               </div>
             </div>
           </div>

--- a/components/Dialogs/infer-deal-dialog.tsx
+++ b/components/Dialogs/infer-deal-dialog.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import * as React from "react";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Bot } from "lucide-react";
+import { InferNewDealComponent } from "../../app/(protected)/infer/InferDealComponent"; // adjust path if needed
+
+export const InferDealDialog = () => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button className="w-full">
+          <Bot className="mr-2 h-4 w-4" /> Infer Deal
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-5xl">
+        <InferNewDealComponent />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/components/Dialogs/infer-deal-dialog.tsx
+++ b/components/Dialogs/infer-deal-dialog.tsx
@@ -1,10 +1,7 @@
-"use client";
-
-import * as React from "react";
-import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Bot } from "lucide-react";
-import { InferNewDealComponent } from "../../app/(protected)/infer/InferDealComponent"; // adjust path if needed
+import { InferNewDealComponent } from "../../app/(protected)/infer/InferDealComponent";
 
 export const InferDealDialog = () => {
   return (
@@ -15,6 +12,7 @@ export const InferDealDialog = () => {
         </Button>
       </DialogTrigger>
       <DialogContent className="max-w-5xl">
+        <DialogTitle>Infer Deal</DialogTitle>
         <InferNewDealComponent />
       </DialogContent>
     </Dialog>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -42,7 +42,7 @@ export const NavLinks: NavLinkType = [
   { navlink: "/new-deal", navlabel: "New", icon: FiPlus },
   { navlink: "/raw-deals", navlabel: "Raw", icon: FiList },
   { navlink: "/published-deals", navlabel: "Published", icon: FiCheckSquare },
-  { navlink: "/infer", navlabel: "Infer", icon: FiSearch },
+  // { navlink: "/infer", navlabel: "Infer", icon: FiSearch },
 ];
 
 const Header = ({ className, session }: HeaderProps) => {


### PR DESCRIPTION
Created infer dialog in the new deal tab with same logic as the old infer page

Deleted the infer button from the header

/infer still routes to the old infer tab, but no button on the header leads to there

New:
![image](https://github.com/user-attachments/assets/75790e50-7319-471d-8720-3d9d0ba48cce)

However, I didn't test it fully because I don't have an openai key

