### PR TITLE
Rate Limit feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,8 @@
         "@tanstack/react-table": "^8.20.6",
         "@types/axios": "^0.9.36",
         "@types/pdf-parse": "^1.1.4",
+        "@upstash/ratelimit": "^2.0.5",
+        "@upstash/redis": "^1.34.9",
         "@vercel/blob": "^0.26.0",
         "ai": "^4.3.10",
         "axios": "^1.8.4",
@@ -3844,6 +3846,39 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+    },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.5.tgz",
+      "integrity": "sha512-1FRv0cs3ZlBjCNOCpCmKYmt9BYGIJf0J0R3pucOPE88R21rL7jNjXG+I+rN/BVOvYJhI9niRAS/JaSNjiSICxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.34.9",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.34.9.tgz",
+      "integrity": "sha512-7qzzF2FQP5VxR2YUNjemWs+hl/8VzJJ6fOkT7O7kt9Ct8olEVzb1g6/ik6B8Pb8W7ZmYv81SdlVV9F6O8bh/gw==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
     },
     "node_modules/@vercel/blob": {
       "version": "0.26.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "@tanstack/react-table": "^8.20.6",
     "@types/axios": "^0.9.36",
     "@types/pdf-parse": "^1.1.4",
+    "@upstash/ratelimit": "^2.0.5",
+    "@upstash/redis": "^1.34.9",
     "@vercel/blob": "^0.26.0",
     "ai": "^4.3.10",
     "axios": "^1.8.4",


### PR DESCRIPTION
Adds an Edge middleware (middleware.ts) with per-route rate limits via Upstash:

Auth Sign-in (POST /api/auth/signin): 5 requests/min

Forgot-password (POST /api/auth/forgot-password): 5 requests/hr

Session (GET /api/auth/session): 30 requests/min

Deals Read (GET /api/deals):* 50 requests/min

Deals Create (POST /api/deals): 10 requests/min

Deals Update (PATCH /api/deals/:id): 20 requests/min

Deals Delete (DELETE /api/deals/:id): 5 requests/min

Status Toggle (POST /api/deals/:id/status): 30 requests/min

Search (GET /api/search): 50 requests/min

AI Analyze (POST /api/ai/analyze): 5 requests/min

File Upload (POST /api/upload): 10 requests/hr

Comments (POST /api/deals/:id/comment): 50 requests/min

Notifications (GET /api/notifications): 30 requests/min

Admin Actions (POST /api/admin/*): 5 requests/min

Global Fallback (any other route): 50 requests/min